### PR TITLE
fix: refactor phone prefix

### DIFF
--- a/app/components/content/SiteContactForm.vue
+++ b/app/components/content/SiteContactForm.vue
@@ -17,12 +17,10 @@ const { t } = useSiteI18n()
 
 type PhonePrefixItem = { label: string, value: string }
 const phonePrefixes = ref<PhonePrefixItem[]>([
-  { label: '+45', value: 'dk' },
-  { label: '+46', value: 'se' },
-  { label: `+47`, value: 'no' },
+  { label: '+45', value: '+45' },
+  { label: '+46', value: '+46' },
+  { label: `+47`, value: '+47' },
 ])
-
-const selectedPhonePrefix = ref<PhonePrefixItem['value']>('dk')
 
 const contactSubjectSelectItems = computed(() => {
   return contactSubjectKeys.map(value => ({
@@ -35,6 +33,7 @@ const DEFAULT_STATE: Partial<ContactFormSchema> = {
   name: undefined,
   email: undefined,
   phone: undefined,
+  phonePrefix: '+45',
   subject: undefined,
   subjectOther: undefined,
   message: undefined,
@@ -115,14 +114,14 @@ watch(() => state.phone, (phone) => {
     }
 
     // lastly, attempt by the already selected item.
-    return p && p.value === selectedPhonePrefix.value && phone.startsWith(p.label)
+    return p && p.value === state.phonePrefix && phone.startsWith(p.label)
   })
 
   if (!selected) return
 
   // prefill countryCode if not the same as set.
-  if (selected.value !== selectedPhonePrefix.value) {
-    selectedPhonePrefix.value = selected.value
+  if (selected.value !== state.phonePrefix) {
+    state.phonePrefix = selected.value
   }
 
   if (!phone.startsWith(selected.label)) return
@@ -186,7 +185,7 @@ function onError(event: FormErrorEvent) {
       >
         <UFieldGroup class="flex content-stretch">
           <USelect
-            v-model="selectedPhonePrefix"
+            v-model="state.phonePrefix"
             :items="phonePrefixes"
             class="min-w-3/12"
           />

--- a/server/api/contact.post.ts
+++ b/server/api/contact.post.ts
@@ -18,7 +18,7 @@ export default defineEventHandler(async (event) => {
     <h2>Ny besked fra kontaktformular</h2>
     <p><strong>Navn:</strong> ${escapeHtml(data.name)}</p>
     <p><strong>Email:</strong> ${escapeHtml(data.email)}</p>
-    <p><strong>Telefon:</strong> ${escapeHtml(data.phone ?? '')}</p>
+    ${data.phone ? `<p><strong>Telefon:</strong> ${escapeHtml(data?.phonePrefix || '')} ${escapeHtml(data.phone ?? '')}</p>` : ''}
     <p><strong>Emne:</strong> ${escapeHtml(safeSubject)}</p>
     <pre style="white-space:pre-wrap">${escapeHtml(data.message)}</pre>
   `.trim()

--- a/shared/schema/forms/contact.ts
+++ b/shared/schema/forms/contact.ts
@@ -37,6 +37,7 @@ export const contactFormSchema = z
       .transform(v => v.replace(/[\s-]/g, ''))
       .refine(v => v === '' || /^\d{8}$/.test(v), { error: 'Telefon skal være 8 cifre.' })
       .optional(),
+    phonePrefix: z.string().optional(),
     subject: z.enum(contactSubjectKeys, { error: 'Vælg et emne.' }),
     subjectOther: z.string().trim().max(120, { error: 'For langt.' }).optional(),
     message: z.string('Besked er påkrævet.').min(1).max(5000, { error: 'Besked er for lang.' }),


### PR DESCRIPTION
handling in contact form and ensure prefix is included in API/Email payload.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Contact form now includes phone prefix field to track international phone information.

* **Bug Fixes**
  * Phone field no longer displays empty sections when no phone number is provided.

* **Updates**
  * Phone prefix values now display in international format (+45, +46, +47) for improved clarity.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->