### PR TITLE
feat(forms): repeatable items

### DIFF
--- a/app/components/account/ChangePasswordModal.vue
+++ b/app/components/account/ChangePasswordModal.vue
@@ -39,7 +39,7 @@ async function onSubmit(payload: FormSubmitEvent<ChangeUserPasswordSchema>) {
 <template>
   <UModal
     v-model:open="displayModal"
-    title="Change Password"
+    :title="$t('auth.dasdsdf')"
   >
     <template #body>
       <UForm

--- a/app/components/form/StepFieldRenderer.vue
+++ b/app/components/form/StepFieldRenderer.vue
@@ -19,7 +19,9 @@ const { t } = useSiteI18n()
 
 const model = computed({
   get: () => props.state[props.field.name],
-  set: (val: unknown) => emit('update:state', props.field.name, val),
+  set: (val: unknown) => {
+    emit('update:state', props.field.name, val)
+  },
 })
 
 // Narrow helpers for typed template access
@@ -69,8 +71,29 @@ const dateModel = computed({
   },
 })
 
+function addEntry() {
+  console.log('addEntry')
+  const current = (model.value as Record<string, unknown>[]) ?? []
+  model.value = [...current, {}]
+}
+
+function removeEntry(index: number) {
+  console.log('removeEntry', { index })
+  const current = [...((model.value as Record<string, unknown>[]) ?? [])]
+  current.splice(index, 1)
+  model.value = current
+}
+
+function updateEntry(index: number, name: string, val: unknown) {
+  console.log('updateEntry', { index, name, val })
+  const current = [...toRaw(((model.value as Record<string, unknown>[]) ?? []))]
+  current[index] = toRaw({ ...current[index], [name]: val })
+  model.value = current
+  console.log('updated', { model: toRaw(current) })
+}
+
 const translated = (property: string) => {
-  const definedValue = props.field[property as keyof typeof props.field] as string | undefined
+  const definedValue = props.field[property as keyof typeof props.field] || props.field.meta[property as keyof typeof props.field] as string | undefined
   if (definedValue) {
     return t(definedValue)
   }
@@ -81,12 +104,14 @@ const translated = (property: string) => {
   // TODO: Might want to not include the automatic field name in some cases?
   // for labels, there is an auto mapper for this
 
+  const whiteListed = ['label', 'add']
+
   // not the i18n key, or if this is the label, we want it anyways.
-  if (autoTranslated !== autoKey || (property === 'label' && definedValue !== '')) {
+  if (autoTranslated !== autoKey || (whiteListed.includes(property) && definedValue !== '')) {
     return autoTranslated
   }
 
-  if (property === 'label' && definedValue !== '') {
+  if (whiteListed.includes(property) && definedValue !== '') {
     return autoTranslated
   }
 
@@ -128,6 +153,50 @@ const fieldProps = computed(() => {
 
 <template>
   <UFormField
+    v-if="field.repeatable && field.fields"
+    v-bind="formFieldProps"
+  >
+    <div class="flex flex-col gap-3">
+      <div
+        v-for="(entry, index) in (model as Record<string, unknown>[])"
+        :key="index"
+        class="relative rounded-lg border border-default p-4"
+      >
+        <!-- Remove button -->
+        <UButton
+          icon="i-lucide-x"
+          color="neutral"
+          variant="ghost"
+          size="xs"
+          class="absolute top-2 right-2"
+          @click="removeEntry(index)"
+        />
+
+        <!-- Sub-fields for this entry -->
+        <div class="flex flex-col gap-3">
+          <StepFieldRenderer
+            v-for="subField in field.fields"
+            :key="subField.name"
+            :field="subField"
+            :state="entry"
+            :i18n-prefix="`${i18nPrefix}${subField.name}.`"
+            @update:state="(name, val) => updateEntry(index, name, val)"
+          />
+        </div>
+      </div>
+
+      <!-- Add button -->
+      <UButton
+        icon="i-lucide-plus"
+        color="neutral"
+        variant="outline"
+        :label="translated('add')"
+        @click="addEntry"
+      />
+    </div>
+  </UFormField>
+  <UFormField
+    v-else
     :key="field.name"
     :name="field.name"
     v-bind="formFieldProps"

--- a/shared/form.ts
+++ b/shared/form.ts
@@ -8,7 +8,7 @@ export function defineSteppedForm<const TSteps extends FormStep[]>(
 ) {
   return form as SteppedForm<TSteps>
 }
-function unwrapSchema(schema: ZodType): { schema: ZodType, isArray: boolean } {
+function unwrapSchema(schema: ZodType): { schema: ZodType, isArray: boolean, repeatable?: boolean } {
   if (schema instanceof z.ZodOptional || schema instanceof z.ZodNullable) {
     return unwrapSchema(schema.unwrap())
   }
@@ -16,14 +16,14 @@ function unwrapSchema(schema: ZodType): { schema: ZodType, isArray: boolean } {
     return unwrapSchema(schema._def.innerType)
   }
   if (schema instanceof z.ZodArray) {
+    const meta = schema.meta?.()
+    const isRepeatable = meta?.repeatable === true
     const { schema: inner } = unwrapSchema(schema.element)
-    return { schema: inner, isArray: true }
+    return { schema: inner, isArray: true, repeatable: isRepeatable }
   }
-  // Take the first union member as the representative type
   if (schema instanceof z.ZodUnion) {
     return unwrapSchema(schema._def.options[0])
   }
-  // z.coerce.number() / z.coerce.boolean() etc. wrap in ZodPipe
   if (schema instanceof z.ZodPipe) {
     return unwrapSchema(schema._def.out)
   }
@@ -43,24 +43,29 @@ export function deriveFieldsFromSchema(schema: ZodType): FormFieldDef[] {
   if (!(schema instanceof z.ZodObject)) return []
 
   return Object.entries(schema.shape).map(([name, fieldSchema]) => {
-    const { schema: resolved, isArray } = unwrapSchema(fieldSchema as ZodType)
+    const { schema: resolved, isArray, repeatable } = unwrapSchema(fieldSchema as ZodType)
 
     const { type, title, description, placeholder, ...meta } = defu(fieldSchema?.meta?.(), resolved.meta?.())
 
     const finalType = fieldSchema.meta()?.type ?? type ?? TYPENAME_MAP[resolved.def.type] ?? resolved.def.type
 
     if (import.meta.dev) {
-      console.log({ name, type: finalType, isArray, title, description, placeholder, meta })
+      console.log({ name, type: finalType, isArray, title, description, placeholder, meta, repeatable })
     }
 
     return {
       name,
       type: finalType as FormFieldDef['type'],
       isArray,
+      repeatable: repeatable || resolved?.meta?.()?.repeatable,
+      // NEW: derive sub-fields when the inner schema is an object
+      fields: (repeatable && resolved instanceof z.ZodObject)
+        ? deriveFieldsFromSchema(resolved)
+        : undefined,
       label: title,
       description,
       placeholder: placeholder as string | undefined,
-      meta: meta,
+      meta,
     }
   })
 }

--- a/shared/schema/forms/applications.ts
+++ b/shared/schema/forms/applications.ts
@@ -91,18 +91,23 @@ export const boardMemberApplicationForm = defineSteppedForm({
       icon: 'i-lucide-book-text',
       labelKey: '**HELLO**',
       schema: z.object({
-        background: z.string().meta({
+        name: z.string(),
+        city: z.string(),
+        email: z.email(),
+        experience: z.array(z.object({
+          startYear: z.date(),
+          endYear: z.date().optional(),
+          description: z.string().meta({ type: 'textarea' }),
+        })).meta({
           type: 'textarea',
-          placeholder: 'enter some text',
+          repeatable: true,
         }),
-        attachments: z.array(z.instanceof(File))
+        image: z.array(z.instanceof(File))
           .meta({
-            title: 'Files',
             type: 'file',
             multiple: true,
-            description: 'Add any attachments you might want to add',
+            description: 'Add your profile photo',
           }),
-        acceptTerms,
       }),
     },
   ],

--- a/shared/types/form.ts
+++ b/shared/types/form.ts
@@ -8,6 +8,10 @@ type BaseField = {
   placeholder?: string
   required?: boolean
   disabled?: boolean
+  isArray?: boolean
+  repeatable?: boolean
+  meta?: Record<string, unknown>
+  fields?: FormFieldDef[]
 }
 
 export type TextField = BaseField & {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added repeatable field support enabling users to add, remove, and manage multiple entries (e.g., experience items) within forms.
  * Restructured board member application form with improved field organization including name, city, email, and experience history.
  * Changed profile attachment field to dedicated profile photo upload.

* **Localization**
  * Updated password change modal title to use localized strings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->