### PR TITLE
fix(auth): add i18n support for ResetPassword component labels and ti…

### DIFF
--- a/app/components/auth/ResetPassword.vue
+++ b/app/components/auth/ResetPassword.vue
@@ -52,18 +52,18 @@ async function onSubmit(payload: FormSubmitEvent<ResetPasswordSchema>) {
     @submit="onSubmit"
   >
     <UPageCard
-      title="Reset password"
+      :title="$t('auth.resetPassword.title')"
       variant="subtle"
       class="space-y-4"
     >
-      <UFormField label="Password">
+      <UFormField :label="$t('auth.resetPassword.new.label')">
         <UInput
           v-model="state.password"
           type="password"
           autocomplete="new-password"
         />
       </UFormField>
-      <UFormField label="Confirm Password">
+      <UFormField :label="$t('auth.resetPassword.confirm.label')">
         <UInput
           v-model="state.confirmPassword"
           type="password"
@@ -78,7 +78,7 @@ async function onSubmit(payload: FormSubmitEvent<ResetPasswordSchema>) {
           :loading="form.loading"
           @click="form.submit()"
         >
-          Reset password
+          {{ $t('auth.resetPassword.title') }}
         </UButton>
       </div>
     </UPageCard>

--- a/i18n/locales/da.json
+++ b/i18n/locales/da.json
@@ -46,6 +46,18 @@
     "provider": {
       "google": "Google",
       "link": "Magic Link"
+    },
+    "resetPassword": {
+      "title": "Endre kodeord",
+      "new": {
+        "label": "Nytt kodeord"
+      },
+      "current": {
+        "label": "Nuværende kodeord"
+      },
+      "confirm": {
+        "label": "Bekræft nytt kodeord"
+      }
     }
   },
   "actions": {

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -51,6 +51,18 @@
     "provider": {
       "google": "Google",
       "link": "Magic Link"
+    },
+    "resetPassword": {
+      "title": "Change password",
+      "new": {
+        "label": "New password"
+      },
+      "current": {
+        "label": "Current password"
+      },
+      "confirm": {
+        "label": "Confirm password"
+      }
     }
   },
   "actions": {


### PR DESCRIPTION
resolves #176 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**Localization**
- Password reset functionality now supports Danish and English languages with fully localized interface elements
- All password reset labels, field prompts, button text, and confirmation messages now display in the user's selected language
- Enhanced accessibility through comprehensive translation of the password change workflow

<!-- end of auto-generated comment: release notes by coderabbit.ai -->