### PR TITLE
fix(auth): simplify `and` condition in reset-password logic

### DIFF
--- a/server/routes/api/auth/reset-password.post.ts
+++ b/server/routes/api/auth/reset-password.post.ts
@@ -11,7 +11,7 @@ export default defineEventHandler(async (event) => {
     .update(schema.passwordResets)
     .set({ usedAt: new Date() })
     .where(
-      () => and(
+      and(
         isNull(schema.passwordResets.usedAt),
         gt(schema.passwordResets.expiresAt, new Date()),
         eq(schema.passwordResets.code, code),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined query construction in password reset logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->