### PR TITLE
chore(config): clarify reason for omitting default R2 bucket name in …

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -35,6 +35,7 @@ export default defineNuxtConfig({
     hub: {
       blob: {
         driver: 'cloudflare-r2',
+        // this is not defined because then it will be defined twice in wrangler.json
         // bucketName: process.env.HUB_BLOB_BUCKET_NAME || 'blob-frigear-nu',
         binding: 'BLOB',
       },


### PR DESCRIPTION
…nuxt.config.ts