### PR TITLE
Clarify omission of default R2 bucket name in configuration

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -35,6 +35,7 @@ export default defineNuxtConfig({
     hub: {
       blob: {
         driver: 'cloudflare-r2',
+        // this is not defined because then it will be defined twice in wrangler.json
         // bucketName: process.env.HUB_BLOB_BUCKET_NAME || 'blob-frigear-nu',
         binding: 'BLOB',
       },


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated configuration documentation to clarify setup requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->