### PR TITLE
fix(form): replace UTooltip with title attribute for hint button

### DIFF
--- a/app/components/form/StepFieldRenderer.vue
+++ b/app/components/form/StepFieldRenderer.vue
@@ -155,14 +155,13 @@ const fieldProps = computed(() => {
         :title="$t('common.information')"
         :ui="{ footer: 'justify-end' }"
       >
-        <UTooltip :text="translatedProperty(field.meta.hint)">
-          <UButton
-            size="sm"
-            icon="i-lucide-info"
-            variant="link"
-            color="neutral"
-          />
-        </UTooltip>
+        <UButton
+          size="sm"
+          icon="i-lucide-info"
+          variant="link"
+          color="neutral"
+          :title="translatedProperty(field.meta.hint)"
+        />
         <template #body>
           {{ translatedProperty(field.meta.hint) }}
         </template>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated the hint info button implementation in the form step field renderer component to use an alternative display method while maintaining the same functionality and user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->