### PR TITLE
feat(forms): add autocomplete meta for name and website fields

### DIFF
--- a/shared/schema/forms/applications.ts
+++ b/shared/schema/forms/applications.ts
@@ -98,6 +98,7 @@ If your project has multiple parts that can be supported, with different budgets
       },
       schema: z.object({
         fullName: z.string().meta({
+          autocomplete: 'name',
           hint: {
             da: 'Dit fulde navn',
             en: 'Your full name',
@@ -138,7 +139,9 @@ If your project has multiple parts that can be supported, with different budgets
         organizationAbout: z.string().meta({
           type: 'textarea',
         }),
-        organizationWebsite: z.string().optional(),
+        organizationWebsite: z.string().optional().meta({
+          autocomplete: 'url',
+        }),
         organizationFacebook: z.string().optional(),
         organizationInstagram: z.string().optional(),
         organizationTikTok: z.string().optional(),


### PR DESCRIPTION
According to: https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Attributes/autocomplete#token_list_tokens

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced form autofill capabilities on application forms. Name and organization website fields now integrate with browser autofill, enabling users to quickly populate these fields using saved browser credentials.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->