### PR TITLE
feat(robots): append hostname to `robots.txt` for non-localhost envir…

### DIFF
--- a/server/plugins/010.robots.ts
+++ b/server/plugins/010.robots.ts
@@ -4,6 +4,7 @@ export default defineNitroPlugin((nitroApp) => {
   nitroApp.hooks.hook('robots:robots-txt', (ctx) => {
     const hostName = getRequestHost(ctx.e)
     if (!hostName.startsWith('localhost') || hostName.startsWith('staging')) {
+      ctx.robotsTxt += `\n#host=${hostName}\n`
       return
     }
 


### PR DESCRIPTION
…onments

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * robots.txt now includes host annotation information for non-localhost and staging environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->