### PR TITLE
fix(i18n): add `target="_BLANK"` to links in terms and privacy policy…

### DIFF
--- a/i18n/locales/da.json
+++ b/i18n/locales/da.json
@@ -499,7 +499,7 @@
     "next": "Videre",
     "submit": "Fyr afsted",
     "acceptTerms": {
-      "description": "Jeg accepterer Frigear [betingelserne](https://frigear.nu/legal/terms) & [privatlivspolitik](https://frigear.nu/legal/gdpr)."
+      "description": "Jeg accepterer Frigear [betingelserne](https://frigear.nu/legal/terms){'{'}target='_BLANK'{'}'} & [privatlivspolitik](https://frigear.nu/legal/gdpr){'{'}target='_BLANK'{'}'}."
     }
   },
   "errors": {

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -438,7 +438,7 @@
     "next": "Continue",
     "submit": "Submit",
     "acceptTerms": {
-      "description": "I accept Frigear [Terms & Conditions](https://frigear.nu/legal/terms) & [Privacy Policy](https://frigear.nu/legal/gdpr)."
+      "description": "I accept Frigear [Terms & Conditions](https://frigear.nu/legal/terms){'{'}target='_BLANK'{'}'} & [Privacy Policy](https://frigear.nu/legal/gdpr){'{'}target='_BLANK'{'}'}."
     }
   },
   "errors": {


### PR DESCRIPTION
… descriptions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * External links in the terms acceptance text now open in a new tab, keeping users on the app while viewing linked documents.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->