### PR TITLE
fix(admin): add `external` prop to download button in `File.vue`

### DIFF
--- a/app/components/admin/form/field/File.vue
+++ b/app/components/admin/form/field/File.vue
@@ -110,6 +110,7 @@ const files = computed(() => {
           class="w-full"
           :ui="{ label: 'truncate' }"
           download
+          external
         >
           {{ media.pathname.split('/').pop() }}
         </UButton>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of non-image/video file downloads to open as external resources, providing better user experience when downloading files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->