### PR TITLE
Simplify Google OAuth provider logic in runtime config

### DIFF
--- a/modules/auth-config.ts
+++ b/modules/auth-config.ts
@@ -19,9 +19,9 @@ export default defineNuxtModule({
 
       // Somehow we cannot read this directly from runtimeConfig from the nuxt instance...
       const rc = useRuntimeConfig()
-      if (rc?.oauth?.google?.clientId) {
-        runtimeConfig.public.auth.providers.push('google')
-      }
+
+      // We always have google auth...?
+      runtimeConfig.public.auth.providers.push('google')
 
       if (rc?.oauth?.facebook?.clientId) {
         runtimeConfig.public.auth.providers.push('facebook')


### PR DESCRIPTION
This pull request makes a small update to the authentication configuration logic. The change ensures that Google authentication is always enabled, regardless of the presence of a Google OAuth client ID in the runtime configuration.

* Always adds `'google'` to the list of authentication providers in `runtimeConfig.public.auth.providers`, instead of conditionally adding it based on the presence of a Google OAuth client ID.…me config