### PR TITLE
chore(oauth): update response handling and ensure JSON Content-Type i…

### DIFF
--- a/modules/oauth-server/runtime/server/routes/oauth/revoke.post.ts
+++ b/modules/oauth-server/runtime/server/routes/oauth/revoke.post.ts
@@ -59,5 +59,5 @@ export default defineEventHandler(async (event) => {
   }
 
   // Always return 200 OK per RFC 7009
-  return {}
+  return sendNoContent(event, 200)
 })

--- a/modules/oauth-server/runtime/server/routes/oauth/token.post.ts
+++ b/modules/oauth-server/runtime/server/routes/oauth/token.post.ts
@@ -155,6 +155,8 @@ export default defineEventHandler(async (event) => {
       )
     }
 
+    setResponseHeader(event, 'Content-Type', 'application/json')
+
     return response
   }
   else {

--- a/modules/oauth-server/runtime/server/routes/oauth/userinfo.get.ts
+++ b/modules/oauth-server/runtime/server/routes/oauth/userinfo.get.ts
@@ -70,5 +70,7 @@ export default defineEventHandler(async (event) => {
     }
   }
 
+  setResponseHeader(event, 'Content-Type', 'application/json')
+
   return response
 })


### PR DESCRIPTION
…n headers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * OAuth token revocation endpoint now properly complies with RFC 7009 by returning HTTP 200 with no response body
  * Fixed Content-Type headers for OAuth token refresh and userinfo endpoints to correctly indicate JSON responses

<!-- end of auto-generated comment: release notes by coderabbit.ai -->