### PR TITLE
feat(admin): add "People Number" column to users table

### DIFF
--- a/app/pages/(admin)/admin/users/index.vue
+++ b/app/pages/(admin)/admin/users/index.vue
@@ -63,6 +63,12 @@ const columns: TableColumn<typeof users.value[number]>[] = [
     cell: ({ row }) => row.original.id,
   },
   {
+    id: 'peopleNumber',
+    header: 'People Number',
+    accessorKey: 'roskildePeopleId',
+    cell: ({ row }) => row.original.roskildePeopleId || 'n/a',
+  },
+  {
     id: 'email',
     header: 'Email',
     accessorKey: 'email',


### PR DESCRIPTION
Added a new column displaying `roskildePeopleId` in the admin users table. Defaults to "n/a" if the value is unavailable.