### PR TITLE
fix(oauth): allow HTTP with local IPs for development

### DIFF
--- a/app/pages/(admin)/admin/oauth/[id].vue
+++ b/app/pages/(admin)/admin/oauth/[id].vue
@@ -78,8 +78,15 @@ function validateUrl(url: string, label: string): string | undefined {
   catch {
     return 'Invalid URL format'
   }
-  // eslint-disable-next-line regexp/no-unused-capturing-group
-  if (!url.startsWith('https://') && !/^http:\/\/localhost(:\d+)?($|\/)/.test(url)) {
+
+  if (
+    !url.startsWith('https://')
+    // eslint-disable-next-line regexp/no-unused-capturing-group
+    && !/^http:\/\/localhost(:\d+)?($|\/)/.test(url)
+    // If not an IP / http://100.70.97.86:3001
+    // eslint-disable-next-line regexp/no-unused-capturing-group
+    && !/^http:\/\/(\d{1,3}\.){3}\d{1,3}(:\d+)?(\/|$)/.test(url)
+  ) {
     return 'Must use HTTPS (http://localhost allowed for development)'
   }
 }

--- a/app/pages/(admin)/admin/oauth/index.vue
+++ b/app/pages/(admin)/admin/oauth/index.vue
@@ -70,8 +70,14 @@ function validateUrl(url: string, label: string): string | undefined {
   catch {
     return `Invalid URL format`
   }
-  // eslint-disable-next-line regexp/no-unused-capturing-group
-  if (!url.startsWith('https://') && !/^http:\/\/localhost(:\d+)?($|\/)/.test(url)) {
+
+  if (
+    !url.startsWith('https://')
+    // eslint-disable-next-line regexp/no-unused-capturing-group
+    && !/^http:\/\/localhost(:\d+)?(\/|$)/.test(url)
+    // eslint-disable-next-line regexp/no-unused-capturing-group
+    && !/^http:\/\/(\d{1,3}\.){3}\d{1,3}(:\d+)?(\/|$)/.test(url)
+  ) {
     return 'Must use HTTPS (http://localhost allowed for development)'
   }
 }

--- a/modules/oauth-server/runtime/server/utils/oauth.ts
+++ b/modules/oauth-server/runtime/server/utils/oauth.ts
@@ -72,9 +72,10 @@ export const FRIGEAR_SSO_CALLBACK_PATH = '/auth/frigear'
  */
 export function requireHttps(url: string): boolean {
   if (url.startsWith('https://')) return true
-  // Allow http://localhost:{port} for development
   // eslint-disable-next-line regexp/no-unused-capturing-group
-  if (/^http:\/\/localhost(:\d+)?($|\/)/.test(url)) return true
+  if (/^http:\/\/localhost(:\d+)?(\/|$)/.test(url)) return true
+  // eslint-disable-next-line regexp/no-unused-capturing-group
+  if (/^http:\/\/(\d{1,3}\.){3}\d{1,3}(:\d+)?(\/|$)/.test(url)) return true
   return false
 }
 


### PR DESCRIPTION
Extended the existing URL validation logic to permit HTTP connections for local IP addresses, maintaining compatibility with localhost during development.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Expanded allowed sign-in and redirect URLs to support `http://localhost` and direct IPv4 addresses in development, while continuing to block other non-HTTPS URLs.
  * Improved URL validation consistency across admin and OAuth flows so local and IP-based environments work as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->