### PR TITLE
feat(account): add BA folder to documents for specific roles

### DIFF
--- a/app/pages/account/documents.vue
+++ b/app/pages/account/documents.vue
@@ -14,7 +14,6 @@ const allowedBARoles = [
 
 const documents = computedAsync(async () => {
   const items = [
-
     {
       path: '/assets/files/Frivillig håndbog.docx',
       name: 'Frivillig Håndbog',
@@ -25,6 +24,11 @@ const documents = computedAsync(async () => {
 
   if (currentUserRole.value && allowedBARoles.includes(currentUserRole.value)) {
     items.unshift({
+      path: '/assets/files/BA-mappe.pdf',
+      name: 'BA-mappe.pdf',
+      nameEn: 'BA-folder.pdf',
+      icon: 'i-lucide-file',
+    }, {
       path: '/assets/files/BA-Koordinatormøde-2503-2026.docx',
       name: 'BA Koordinatormøde 25.03.2026',
       nameEn: 'BA Coordinatormeeting 25.03.2026',


### PR DESCRIPTION
Included "BA-mappe.pdf" in the documents list for users with eligible roles

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new document card for eligible BA roles, showing “BA-mappe.pdf” in the documents list.
  * The new document is displayed with localized labels and a file icon, and appears near the top of the list.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->